### PR TITLE
Add bestiary & example monsters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Initialize bestiary with two sample monsters [#12](https://github.com/jeromecovington/sysref-base/pull/12)
+
 ## 0.3.0
 - Breaking: add "real" weapons [#7](https://github.com/jeromecovington/sysref-base/pull/7)
 - Breaking: add "real" armor map and update armor class algorithm [#5](https://github.com/jeromecovington/sysref-base/pull/5)

--- a/examples/combat.js
+++ b/examples/combat.js
@@ -3,6 +3,8 @@ const { BaseCreature, BaseRoll, roll } = require('../index')
 const weaponMap = require('../src/weapons/map')
 const armorMap = require('../src/armor/map')
 
+const Orc = require('../src/bestiary/Orc')
+
 const Warrior = new BaseCreature({
   strength: 12,
   dexterity: 3,
@@ -18,22 +20,6 @@ Warrior.setHitPoints(0)
 Warrior.setInventory({ weapon: 'longSword', armor: 'chainmail' })
 Warrior.setWeaponEquipped('longSword')
 Warrior.setArmorEquipped('chainmail')
-
-const Orc = new BaseCreature({
-  strength: 10,
-  dexterity: 5,
-  constitution: 10,
-  intelligence: 3,
-  wisdom: 2,
-  charisma: 1,
-  advantages: ['strength'],
-  disadvantages: ['intelligence', 'wisdom'],
-  hitPointsRollFunc: () => roll(1, 10)
-})
-Orc.setHitPoints(0)
-Orc.setInventory({ weapon: 'warhammer', armor: 'leather' })
-Orc.setWeaponEquipped('warhammer')
-Orc.setArmorEquipped('leather')
 
 const Roll = new BaseRoll({
   weaponMap,

--- a/src/bestiary/Goblin.js
+++ b/src/bestiary/Goblin.js
@@ -12,8 +12,8 @@ module.exports = provider({
   disadvantages: [],
   hitPointsRollFunc: () => roll(2, 12),
   hitPointsModifier: 0,
-  armor: 'leather',
-  weapon: 'shortSword',
-  treasure: 50,
+  armor: ['leather', 'shield'],
+  weapon: ['shortSword', 'shortBow'],
+  treasure: [50],
   name: 'Goblin'
 })

--- a/src/bestiary/Goblin.js
+++ b/src/bestiary/Goblin.js
@@ -1,0 +1,19 @@
+const { provider } = require('./helper')
+const { roll } = require('../roll/helper')
+
+module.exports = provider({
+  strength: 8,
+  dexterity: 14,
+  constitution: 10,
+  intelligence: 10,
+  wisdom: 8,
+  charisma: 8,
+  advantages: [],
+  disadvantages: [],
+  hitPointsRollFunc: () => roll(2, 12),
+  hitPointsModifier: 0,
+  armor: 'leather',
+  weapon: 'shortSword',
+  treasure: 50,
+  name: 'Goblin'
+})

--- a/src/bestiary/Orc.js
+++ b/src/bestiary/Orc.js
@@ -12,8 +12,8 @@ module.exports = provider({
   disadvantages: [],
   hitPointsRollFunc: () => roll(2, 16),
   hitPointsModifier: 6,
-  armor: 'hide',
-  weapon: 'greatAxe',
-  treasure: 100,
+  armor: ['hide'],
+  weapon: ['greatAxe', 'javelin'],
+  treasure: [100],
   name: 'Orc'
 })

--- a/src/bestiary/Orc.js
+++ b/src/bestiary/Orc.js
@@ -1,0 +1,19 @@
+const { provider } = require('./helper')
+const { roll } = require('../roll/helper')
+
+module.exports = provider({
+  strength: 16,
+  dexterity: 12,
+  constitution: 16,
+  intelligence: 7,
+  wisdom: 11,
+  charisma: 10,
+  advantages: [],
+  disadvantages: [],
+  hitPointsRollFunc: () => roll(2, 16),
+  hitPointsModifier: 6,
+  armor: 'hide',
+  weapon: 'greatAxe',
+  treasure: 100,
+  name: 'Orc'
+})

--- a/src/bestiary/helper.js
+++ b/src/bestiary/helper.js
@@ -1,6 +1,6 @@
 const BaseCreature = require('../creature/BaseCreature')
 
-module.exports = function provider ({
+function provider ({
   strength,
   dexterity,
   constitution,
@@ -35,4 +35,8 @@ module.exports = function provider ({
   creature.name = name
 
   return creature
+}
+
+module.exports = {
+  provider
 }

--- a/src/bestiary/helper.js
+++ b/src/bestiary/helper.js
@@ -11,9 +11,9 @@ function provider ({
   disadvantages,
   hitPointsRollFunc,
   hitPointsModifier = 0,
-  armor,
-  weapon,
-  treasure,
+  armor = [],
+  weapon = [],
+  treasure = [],
   name
 }) {
   const creature = new BaseCreature({
@@ -29,9 +29,32 @@ function provider ({
   })
 
   creature.setHitPoints(hitPointsModifier)
-  creature.setInventory({ armor, weapon, treasure })
-  creature.setArmorEquipped(armor)
-  creature.setWeaponEquipped(weapon)
+
+  if (armor) {
+    creature.setInventory({ armor })
+    creature.setArmorEquipped(armor)
+  }
+
+  if (armor.length) {
+    armor.forEach(a => {
+      creature.setInventory({ armor: a })
+    })
+    creature.setArmorEquipped(armor[0])
+  }
+
+  if (weapon.length) {
+    weapon.forEach(w => {
+      creature.setInventory({ weapon: w })
+    })
+    creature.setWeaponEquipped(weapon[0])
+  }
+
+  if (treasure.length) {
+    treasure.forEach(t => {
+      creature.setInventory({ treasure: t })
+    })
+  }
+
   creature.name = name
 
   return creature

--- a/src/bestiary/helpers.js
+++ b/src/bestiary/helpers.js
@@ -1,0 +1,38 @@
+const BaseCreature = require('../creature/BaseCreature')
+
+module.exports = function provider ({
+  strength,
+  dexterity,
+  constitution,
+  intelligence,
+  wisdom,
+  charisma,
+  advantages,
+  disadvantages,
+  hitPointsRollFunc,
+  hitPointsModifier = 0,
+  armor,
+  weapon,
+  treasure,
+  name
+}) {
+  const creature = new BaseCreature({
+    strength,
+    dexterity,
+    constitution,
+    intelligence,
+    wisdom,
+    charisma,
+    advantages,
+    disadvantages,
+    hitPointsRollFunc
+  })
+
+  creature.setHitPoints(hitPointsModifier)
+  creature.setInventory({ armor, weapon, treasure })
+  creature.setArmorEquipped(armor)
+  creature.setWeaponEquipped(weapon)
+  creature.name = name
+
+  return creature
+}

--- a/src/roll/helper.js
+++ b/src/roll/helper.js
@@ -30,12 +30,12 @@ function getArmorClass (entity, armorMap) {
     const armorModifier = armor ? armor.modifier : 0
 
     // https://5thsrd.org/rules/abilities/dexterity/
-    let dexterityModifier = 0;
+    let dexterityModifier = 0
     if (armor.usesDexterity) {
       dexterityModifier = getModifier(entity.getAbility('dexterity'))
     }
     if (armor.maxDexterity) {
-      dexterityModifier = Math.min(dexterityModifier, armor.maxDexterity);
+      dexterityModifier = Math.min(dexterityModifier, armor.maxDexterity)
     }
 
     return armorModifier + dexterityModifier

--- a/src/weapons/map.js
+++ b/src/weapons/map.js
@@ -76,7 +76,7 @@ module.exports = {
     hasAmmunition: true,
     minMax: [1, 4]
   },
-  battleaxe: {
+  battleAxe: {
     abilities: ['strength'],
     classification: ['melee'],
     cost: 10,

--- a/src/weapons/map.js
+++ b/src/weapons/map.js
@@ -55,12 +55,6 @@ module.exports = {
     cost: 1,
     minMax: [1, 4]
   },
-  sickle: {
-    abilities: ['strength'],
-    classification: ['melee', 'ranged'],
-    cost: 1,
-    minMax: [1, 6]
-  },
   lightCrossbow: {
     abilities: ['strength'],
     classification: ['ranged'],
@@ -162,4 +156,4 @@ module.exports = {
     hasAmmunition: true,
     minMax: [1, 8]
   }
-};
+}

--- a/test/bestiary/helper.test.js
+++ b/test/bestiary/helper.test.js
@@ -23,9 +23,9 @@ describe('bestiary helper', () => {
       disadvantages: ['dexterity', 'charisma'],
       hitPointsRollFunc: () => 10,
       hitPointsModifier: 10,
-      armor: 'studdedLeather',
-      weapon: 'trident',
-      treasure: 10,
+      armor: ['studdedLeather'],
+      weapon: ['trident'],
+      treasure: [10],
       name: 'foo monster'
     })
   })

--- a/test/bestiary/helper.test.js
+++ b/test/bestiary/helper.test.js
@@ -1,0 +1,71 @@
+const {
+  afterEach,
+  beforeEach,
+  describe,
+  it
+} = require('mocha')
+const { expect } = require('chai')
+
+const { provider } = require('../../src/bestiary/helper')
+
+describe('bestiary helper', () => {
+  let monster
+
+  beforeEach(() => {
+    monster = provider({
+      strength: 10,
+      dexterity: 10,
+      constitution: 10,
+      intelligence: 10,
+      wisdom: 10,
+      charisma: 10,
+      advantages: ['strength', 'intelligence'],
+      disadvantages: ['dexterity', 'charisma'],
+      hitPointsRollFunc: () => 10,
+      hitPointsModifier: 10,
+      armor: 'studdedLeather',
+      weapon: 'trident',
+      treasure: 10,
+      name: 'foo monster'
+    })
+  })
+
+  afterEach(() => {
+    monster = null
+  })
+
+  describe('provider', () => {
+    it('should set abilities', () => {
+      expect(monster.getAbility('strength')).to.equal(10)
+      expect(monster.getAbility('dexterity')).to.equal(10)
+      expect(monster.getAbility('constitution')).to.equal(10)
+      expect(monster.getAbility('intelligence')).to.equal(10)
+      expect(monster.getAbility('wisdom')).to.equal(10)
+      expect(monster.getAbility('charisma')).to.equal(10)
+    })
+
+    it('should set advantages', () => {
+      expect(monster.getAdvantages()).to.deep.equal(['strength', 'intelligence'])
+    })
+
+    it('should set disadvantages', () => {
+      expect(monster.getDisadvantages()).to.deep.equal(['dexterity', 'charisma'])
+    })
+
+    it('should set hitpoints', () => {
+      expect(monster.getHitPoints()).to.equal(20)
+    })
+
+    it('should set armor', () => {
+      expect(monster.getArmorEquipped()).to.equal('studdedLeather')
+    })
+
+    it('should set weapon', () => {
+      expect(monster.getWeaponEquipped()).to.equal('trident')
+    })
+
+    it('should set name', () => {
+      expect(monster.name).to.equal('foo monster')
+    })
+  })
+})


### PR DESCRIPTION
Adds bestiary helper (provider) and two sample monsters (goblin & orc).

Partially addresses: https://github.com/jeromecovington/sysref-base/issues/10