### PR TITLE
Export base monster class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Unreleased
-- Add BaseCharacter class and tests (not yet implemented) [#17](https://github.com/jeromecovington/sysref-base/pull/17)
-- Refactor bestiary provider to BaseMonster class [#16](https://github.com/jeromecovington/sysref-base/pull/16)
+- Export `BaseMonster` class [#19](https://github.com/jeromecovington/sysref-base/pull/19)
+- Add `BaseCharacter` class and tests (not yet implemented) [#17](https://github.com/jeromecovington/sysref-base/pull/17)
+- Refactor bestiary provider to `BaseMonster` class [#16](https://github.com/jeromecovington/sysref-base/pull/16)
 - Implement xp in bestiary [#15](https://github.com/jeromecovington/sysref-base/pull/15)
 
 ## 0.4.0

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   BaseCreature: require('./src/creature/BaseCreature'),
+  BaseMonster: require('./src/bestiary/BaseMonster'),
   BaseRoll: require('./src/roll/BaseRoll'),
   roll: require('./src/roll/helper').roll,
   d20Roll: require('./src/roll/helper').d20Roll,


### PR DESCRIPTION
Export `BaseMonster` for easier implementation in userland.

Partially addresses: https://github.com/jeromecovington/sysref-base/issues/10